### PR TITLE
Redesign TV Show Trends search and chart interface

### DIFF
--- a/app/assets/javascripts/charts/charts.js
+++ b/app/assets/javascripts/charts/charts.js
@@ -36,9 +36,17 @@ angular.module('TVCharts.Charts', [
   chartsCtrl.setOptSelect = setOptSelect;
   chartsCtrl.scrubDatasets = scrubDatasets;
   chartsCtrl.showHelp = showHelp;
+  chartsCtrl.search = search;
+  chartsCtrl.detectSearchInput = detectSearchInput;
+  chartsCtrl.toggleTheme = toggleTheme;
   chartsCtrl.myCharts = {};
   chartsCtrl.loading = false;
   chartsCtrl.showCanvas = false;
+  chartsCtrl.error_message = '';
+  chartsCtrl.search_query = '';
+  chartsCtrl.search_is_imdb = false;
+  chartsCtrl.search_hint = 'Search by title, IMDb ID, or IMDb URL';
+  chartsCtrl.summary_cards = [];
   chartsCtrl.series_list = [];
   chartsCtrl.datasets = [];
   chartsCtrl.labels = [];
@@ -48,8 +56,15 @@ angular.module('TVCharts.Charts', [
   chartsCtrl.compNormType = 's-left';
   chartsCtrl.compSeasonAlign = 'left';
   chartsCtrl.compEpAlign = 'left';
-  chartsCtrl.connectSeasons = false;
-  chartsCtrl.fill = true;
+  chartsCtrl.connectSeasons = true;
+  chartsCtrl.fill = false;
+  chartsCtrl.focusedScale = false;
+  try {
+    var storedTheme = $window.localStorage.getItem('tvcharts-theme');
+    chartsCtrl.darkMode = storedTheme ? storedTheme == 'dark' : ($window.matchMedia && $window.matchMedia('(prefers-color-scheme: dark)').matches);
+  } catch(e) {
+    chartsCtrl.darkMode = false;
+  }
 
   // comparison possibilities
   // 1. Normalization: full, season-left, season-right
@@ -81,11 +96,12 @@ angular.module('TVCharts.Charts', [
   }
 
   function init() {
-    var shows = $state.params['query'].split(",")
-    paramsMap = shows.map(function(el){
-      imdb_id = null;
-      series = null;
-      year = null;
+    var query = $state.params['query'] || '';
+    var shows = query.split(",");
+    var paramsMap = shows.map(function(el){
+      var imdb_id = null;
+      var series = null;
+      var year = null;
       if(el.match(/i=/)){
         imdb_id = el.match(/i=([^&]*)/)[1];
       }
@@ -101,7 +117,7 @@ angular.module('TVCharts.Charts', [
       if(series != null || imdb_id != null){
         return [series, year, imdb_id]
       }
-    });
+    }).filter(function(el){ return el != null; });
     if(paramsMap[0] != undefined){
       get_trend_from_url(paramsMap);
     }
@@ -112,6 +128,43 @@ angular.module('TVCharts.Charts', [
   /*********************
   *  Private functions *
   * *******************/
+
+  function extractImdbId(value){
+    var input = (value || '').trim();
+    var directMatch = input.match(/^(tt\d{7,10})$/i);
+    var urlMatch = input.match(/imdb\.com\/title\/(tt\d{7,10})/i);
+    var match = directMatch || urlMatch;
+    return match ? match[1].toLowerCase() : null;
+  }
+
+  function detectSearchInput(){
+    var imdbId = extractImdbId(chartsCtrl.search_query);
+    chartsCtrl.search_is_imdb = imdbId != null;
+    chartsCtrl.search_hint = imdbId ? 'IMDb ID detected: ' + imdbId : 'Title search — year can help distinguish remakes';
+    return imdbId;
+  }
+
+  function search(add){
+    var query = (chartsCtrl.search_query || '').trim();
+    if(!query || chartsCtrl.loading){ return; }
+
+    var imdbId = extractImdbId(query);
+    chartsCtrl.search_is_imdb = imdbId != null;
+    chartsCtrl.error_message = '';
+    get_trend(imdbId ? null : query, imdbId ? null : chartsCtrl.year, imdbId, add === true);
+  }
+
+  function toggleTheme(){
+    chartsCtrl.darkMode = !chartsCtrl.darkMode;
+    try {
+      $window.localStorage.setItem('tvcharts-theme', chartsCtrl.darkMode ? 'dark' : 'light');
+    } catch(e) { /* local storage may be unavailable */ }
+
+    if(chartsCtrl.options_object){
+      set_options(chartsCtrl.options_object);
+      set_dataset_override(chartsCtrl.chart_title.length > 1);
+    }
+  }
 
   function setOptSelect(){
     if(chartsCtrl.compType == 's-align'){
@@ -136,10 +189,11 @@ angular.module('TVCharts.Charts', [
   function get_trend_from_url(arr){
     var canvas = document.getElementById('chart');
     chartsCtrl.loading = true;
+    chartsCtrl.error_message = '';
     chartsCtrl.watch_link = [];
-    paramsArr = arr.map(function(el){
+    var paramsArr = arr.map(function(el){
       if(!el[2]){
-        param = 't=' + encodeURIComponent(el[0])
+        var param = 't=' + encodeURIComponent(el[0]);
         if(el[1]){
           param += '&y=' + el[1];
         }
@@ -155,32 +209,42 @@ angular.module('TVCharts.Charts', [
         chartsCtrl.loading = false;
         chartsCtrl.showCanvas = false;
         chartsCtrl.series_list = {};
-        // [chartsCtrl.loading, chartsCtrl.showCanvas, chartsCtrl.series_list] = returnError()
         if(canvas){
           var ctx = canvas.getContext('2d');
-          ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+          ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
         }
-        chartsCtrl.chart_title.push(["Series not found", "#"]);
+        chartsCtrl.error_message = 'We could not find that series. Check the title or IMDb ID and try again.';
         return false;
       }
 
-      episodeQuery = response.data.map(function(el){ return [el.imdbID, el.Title] });
+      var episodeQuery = response.data.map(function(el){ return [el.imdbID, el.Title] });
       chartsCtrl.imdbId = episodeQuery.map(function(el){ return el[0] });
       chartsCtrl.chart_title = episodeQuery.map(function(el){ return [el[1], "https://www.justwatch.com/us/search?q=" + encodeURI(el[1])] });
+      chartsCtrl.search_query = episodeQuery[0][1];
+      detectSearchInput();
       
       // get actual episode data
       episodesFactory.getEpisodesBatch(episodeQuery.join("|"))
       .then(function(response){
-        chartsCtrl.series_list = response.data
+        chartsCtrl.series_list = response.data;
 
         // draw chart
         organize_chart_data(chartsCtrl.series_list);
-      })
+      });
+    })
+    ['catch'](function(err){
+      $log.log('get_trend_from_url error: ' + err);
+      chartsCtrl.loading = false;
+      chartsCtrl.showCanvas = false;
+      chartsCtrl.error_message = 'Something went wrong while loading the series. Please try again.';
     });
   }
 
   function get_trend(series, year, imdb_id, add) {
     var canvas = document.getElementById('chart');
+    var existingSeries = chartsCtrl.series_list.slice ? chartsCtrl.series_list.slice() : [];
+    var existingTitles = chartsCtrl.chart_title.slice();
+    var existingIds = chartsCtrl.imdbId.slice();
     if(!add){
       // if this isn't an additive function, start over
       chartsCtrl.chart_title = [];
@@ -192,17 +256,19 @@ angular.module('TVCharts.Charts', [
       // destroy existing chart via angular-chart.js event
       $scope.$broadcast('chart-destroy');
     }
+    chartsCtrl.error_message = '';
     // set params
+    var params;
     if(!imdb_id){
-      var params = 't=' + encodeURIComponent(series);
+      params = 't=' + encodeURIComponent(series);
       if(year){
         params = params + '&y=' + year;
       }
     }else{
-      var params = 'i=' + imdb_id;
+      params = 'i=' + imdb_id;
     }
     // set url based on params provided
-    window.history.pushState('abcdef', 'Title', '/' + [params, chartsCtrl.imdbId.map(function(el){ return 'i=' + el }).join(',')].filter(function(el){ return el }).join(','));
+    $window.history.pushState(null, 'TV Show Trends', '/' + [params, chartsCtrl.imdbId.map(function(el){ return 'i=' + el }).join(',')].filter(function(el){ return el; }).join(','));
     chartsCtrl.loading = true;
 
     // get imdb ID and clean title
@@ -210,21 +276,29 @@ angular.module('TVCharts.Charts', [
     .then(function(response){
       if(response.data.Response == "False"){
         chartsCtrl.loading = false;
-        chartsCtrl.showCanvas = false;
-        chartsCtrl.series_list = [];
-        if(canvas){
+        chartsCtrl.error_message = 'We could not find that series. Check the title or IMDb ID and try again.';
+        if(add){
+          chartsCtrl.series_list = existingSeries;
+          chartsCtrl.chart_title = existingTitles;
+          chartsCtrl.imdbId = existingIds;
+        }else{
+          chartsCtrl.showCanvas = false;
+          chartsCtrl.series_list = [];
+        }
+        if(canvas && !add){
           canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
         }
-        chartsCtrl.chart_title.push(["Series not found", "#"]);
         return;
       }
-      var imdb_id = response.data.imdbID;
-      chartsCtrl.imdbId.push(imdb_id);
+      var resolvedImdbId = response.data.imdbID;
+      chartsCtrl.imdbId.push(resolvedImdbId);
       var title = response.data.Title;
       chartsCtrl.chart_title.push([title, "https://www.justwatch.com/us/search?q=" + encodeURI(title)]);
+      chartsCtrl.search_query = title;
+      detectSearchInput();
 
       // get actual episode data
-      return episodesFactory.getEpisodes(imdb_id, title)
+      return episodesFactory.getEpisodes(resolvedImdbId, title)
       .then(function(response){
         chartsCtrl.series_list.push(response.data);
         organize_chart_data(chartsCtrl.series_list);
@@ -233,42 +307,66 @@ angular.module('TVCharts.Charts', [
     ['catch'](function(err) {
       $log.log('get_trend error: ' + err);
       chartsCtrl.loading = false;
-      chartsCtrl.showCanvas = false;
-      chartsCtrl.series_list = [];
-      if(canvas){
+      chartsCtrl.error_message = 'Something went wrong while loading the series. Please try again.';
+      if(add){
+        chartsCtrl.series_list = existingSeries;
+        chartsCtrl.chart_title = existingTitles;
+        chartsCtrl.imdbId = existingIds;
+      }else{
+        chartsCtrl.showCanvas = false;
+        chartsCtrl.series_list = [];
+      }
+      if(canvas && !add){
         canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
       }
-      chartsCtrl.chart_title.push(["Error loading series data", "#"]);
       if(!$scope.$$phase){ $scope.$apply(); }
     });
   }
   
   function set_options(opts){
     var seasons = opts['seasons'];
+    var ep_data;
     if(chartsCtrl.connectSeasons){
-      shows = [...new Set(opts['ep_data'].flat().map(function(e){ return e['Show Title'] }) )];
-      var ep_data = [];
+      var shows = [...new Set(opts['ep_data'].flat().map(function(e){ return e['Show Title']; }) )];
+      ep_data = [];
       opts['ep_data'].flat().forEach(function(e){
-        var arr = ep_data[shows.indexOf(e['Show Title'])]
+        var arr = ep_data[shows.indexOf(e['Show Title'])];
         if(!arr){
           ep_data.push([e]);
         }else{
           arr.push(e);
         }
-      })
+      });
     }else{
-      var ep_data = opts['ep_data'];
+      ep_data = opts['ep_data'];
     }
 
+    var label_store;
     if(chartsCtrl.chart_title.length > 1){
-      var label_store = []
+      label_store = [];
       for(var i = 0; i < opts['label_store'].length; i++){
-        label_store.push(i)
+        label_store.push(i + 1);
       }
     }else{
-      var label_store = opts['label_store'];
+      label_store = opts['label_store'];
     }
     var link_base = "https://www.imdb.com/title/";
+    var ratings = ep_data.flat().map(function(e){ return parseFloat(e['imdbRating']); }).filter(function(rating){ return !isNaN(rating); });
+    var lowestRating = ratings.length ? Math.min.apply(null, ratings) : 5;
+    var axisMinimum = chartsCtrl.focusedScale ? (lowestRating < 5 ? Math.floor(lowestRating) : 5) : 0;
+    var theme = chartsCtrl.darkMode ? {
+      text: 'rgba(245,247,250,0.88)',
+      muted: 'rgba(226,232,240,0.62)',
+      grid: 'rgba(226,232,240,0.13)',
+      tooltip: 'rgba(15,23,42,0.96)'
+    } : {
+      text: 'rgba(30,41,59,0.88)',
+      muted: 'rgba(71,85,105,0.68)',
+      grid: 'rgba(71,85,105,0.14)',
+      tooltip: 'rgba(15,23,42,0.94)'
+    };
+
+    chartsCtrl.rating_axis_min = axisMinimum;
     
     chartsCtrl.options = {
       elements: {
@@ -279,6 +377,7 @@ angular.module('TVCharts.Charts', [
       legend: {
         display: true,
         labels: {
+          fontColor: theme.text,
           generateLabels: function(chart){
             var theHelp = Chart.helpers;
             var data = chart.data;
@@ -307,7 +406,7 @@ angular.module('TVCharts.Charts', [
             return [];
           },
           filter: function(legendItem, chartData){
-            if(legendItem.text != "trend"){
+            if(legendItem.text.indexOf(' trend') == -1){
               return true;
             }
           }
@@ -328,9 +427,11 @@ angular.module('TVCharts.Charts', [
           }
           // hide/unhide associated trend dataset
           if(chartsCtrl.trends){
-            metaTrend.hidden = metaTrend.hidden === null ? !ci.data.datasets[index + 1].hidden : null;
+            if(metaTrend){
+              metaTrend.hidden = metaTrend.hidden === null ? !ci.data.datasets[index + 1].hidden : null;
+            }
           }else{
-            metaTrend.hidden = true;
+            if(metaTrend){ metaTrend.hidden = true; }
           }
           
           ci.update();
@@ -341,6 +442,9 @@ angular.module('TVCharts.Charts', [
       },
 			tooltips: {
 			  mode: 'single',
+        backgroundColor: theme.tooltip,
+        titleFontColor: 'rgba(255,255,255,0.96)',
+        bodyFontColor: 'rgba(255,255,255,0.92)',
         callbacks: {
           title: function(tooltipItem) {
             if(tooltipItem[0] != undefined){
@@ -390,20 +494,26 @@ angular.module('TVCharts.Charts', [
             maxRotation: 75,
             minRotation: 25,
             stepSize: 1,
+            fontColor: theme.muted,
             userCallback: function(label, index, labels){
               return label_store[label];
             }
-          }
+          },
+          gridLines: { color: theme.grid }
         }],
         yAxes: [{
           scaleLabel: {
             display: true,
-            labelString: "IMDB Rating"
+            labelString: "IMDb rating",
+            fontColor: theme.muted
           },
           ticks: {
-            min: 0,
-            max: 10
-          }
+            min: axisMinimum,
+            max: 10,
+            stepSize: axisMinimum < 3 ? 2 : 1,
+            fontColor: theme.muted
+          },
+          gridLines: { color: theme.grid }
         }]
       },
       onClick: function(ev, el){
@@ -418,51 +528,54 @@ angular.module('TVCharts.Charts', [
   }
   
   function set_dataset_override(multi){
-    opts = chartsCtrl.options_object;
+    var opts = chartsCtrl.options_object;
 
     // ignore if opts isn't set yet
     if(opts == null){
       return true;
     }
+    var series_labels;
     if(chartsCtrl.connectSeasons){
-      var series_labels = [...new Set(opts['ep_data'].map(function(e){ return e[0]['Show Title'] }) )];
+      series_labels = [...new Set(opts['ep_data'].map(function(e){ return e[0]['Show Title']; }) )];
     }else{
-      var series_labels = opts['series_labels'];
+      series_labels = opts['series_labels'];
     }
     var colors = opts['colors'];
     
     chartsCtrl.dataset_override = [];
 
-    i = 0;
+    var i = 0;
     // handle seasons with one single episode
     chartsCtrl.datasets = chartsCtrl.datasets.filter(function(e){ return e.length > 0 });
 
-    titles = chartsCtrl.datasets.filter(function(e){ return e[0]['type'] == "ep" }).map(function(e){ return e[0]['show'] });
-    titlesUniq = [...new Set(titles)]
+    var titles = chartsCtrl.datasets.filter(function(e){ return e[0]['type'] == "ep"; }).map(function(e){ return e[0]['show']; });
+    var titlesUniq = [...new Set(titles)];
     series_labels.forEach(function(s){
+      var colorIndex = multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s);
+      var color = colors[Math.max(0, colorIndex)] || colors[0];
       chartsCtrl.dataset_override.push(
         {
           label: s,
           borderWidth: 2,
           type: "line",
-          borderColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.8)"),
-          backgroundColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.1)"),
-          pointBorderColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.8)"),
-          pointBackgroundColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.8)"),
-          pointHoverBorderColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.8)"),
-          pointHoverBackgroundColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.8)"),
+          borderColor: color.replace("1)", "0.88)"),
+          backgroundColor: color.replace("1)", "0.10)"),
+          pointBorderColor: color.replace("1)", "0.9)"),
+          pointBackgroundColor: color.replace("1)", "0.9)"),
+          pointHoverBorderColor: color,
+          pointHoverBackgroundColor: color,
+          fill: chartsCtrl.fill,
           hidden: !chartsCtrl.episode_data
         },{
-          label: "trend",
-          borderWidth: 1,
+          label: s + " trend",
+          borderWidth: 2,
           type: 'line',
           borderDash: [10,5],
-          borderColor: chartsCtrl.episode_data ? colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.4)") : colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("opac", "0.8"), // light trendlines unless only trendlines are being shown
-          backgroundColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.1)"),
-          pointBorderColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.5)"),
-          pointBackgroundColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.2)"),
-          pointHoverBorderColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.5)"),
-          pointHoverBackgroundColor: colors[multi ? titlesUniq.indexOf(titles[i]) : series_labels.indexOf(s)].replace("1)", "0.2)"),
+          borderColor: chartsCtrl.episode_data ? color.replace("1)", "0.58)") : color.replace("1)", "0.9)"),
+          backgroundColor: 'transparent',
+          pointRadius: 0,
+          pointHoverRadius: 0,
+          fill: false,
           hidden: !chartsCtrl.trends
         }
       );
@@ -863,19 +976,70 @@ angular.module('TVCharts.Charts', [
       return "rgba(" + String(Math.round(r * 255)) + "," + String(Math.round(g * 255)) + "," + String(Math.round(b * 255)) + ",1)";
     }
     
-    colors = [];
+    var colors = [];
     // cycle through and create colors
     if(n < 1) { return [hslToRgb(1.0, 1.0, .7)] }
     for(var i = 0; i < n; i++){
       colors.push(hslToRgb((i * (360.0 / n) % 360)/360.0,1.0,.4));
     }
 
-    // sort colors randomly
-    if(rnd){
-      return colors.sort(function(){ return Math.random() - 0.5 });
-    }else{
-      return colors
+    return colors;
+  }
+
+  function updateSummaryCards(raw){
+    var stats = raw.map(function(series, seriesIndex){
+      var episodes = [];
+      Object.keys(series).sort(function(a, b){ return parseInt(a) - parseInt(b); }).forEach(function(season){
+        series[season].forEach(function(episode){
+          var rating = parseFloat(episode['imdbRating']);
+          if(isNaN(rating)){ return; }
+          episodes.push({
+            rating: rating,
+            title: episode['Title'],
+            season: season,
+            episode: episode['Episode']
+          });
+        });
+      });
+
+      if(!episodes.length){ return null; }
+      var total = episodes.reduce(function(sum, episode){ return sum + episode.rating; }, 0);
+      var highest = episodes.reduce(function(best, episode){ return episode.rating > best.rating ? episode : best; }, episodes[0]);
+      return {
+        title: chartsCtrl.chart_title[seriesIndex] ? chartsCtrl.chart_title[seriesIndex][0] : 'Series ' + (seriesIndex + 1),
+        average: total / episodes.length,
+        highest: highest,
+        first: episodes[0].rating,
+        last: episodes[episodes.length - 1].rating,
+        count: episodes.length
+      };
+    }).filter(function(stat){ return stat != null; });
+
+    if(!stats.length){
+      chartsCtrl.summary_cards = [];
+      return;
     }
+
+    if(stats.length == 1){
+      var stat = stats[0];
+      var delta = stat.last - stat.first;
+      var direction = delta > 0.15 ? 'Rising' : (delta < -0.15 ? 'Falling' : 'Steady');
+      chartsCtrl.summary_cards = [
+        { label: 'Series average', value: stat.average.toFixed(1), context: stat.count + ' rated episodes' },
+        { label: 'Highest rated', value: stat.highest.rating.toFixed(1), context: (stat.highest.title || ('S' + stat.highest.season + ' E' + stat.highest.episode)) },
+        { label: 'Overall trend', value: direction, context: (delta >= 0 ? '+' : '') + delta.toFixed(1) + ' premiere to finale' }
+      ];
+      return;
+    }
+
+    var averages = stats.map(function(stat){ return stat.average; });
+    var finales = stats.map(function(stat){ return stat.last; });
+    var leader = stats.reduce(function(best, stat){ return stat.average > best.average ? stat : best; }, stats[0]);
+    chartsCtrl.summary_cards = [
+      { label: 'Average gap', value: (Math.max.apply(null, averages) - Math.min.apply(null, averages)).toFixed(1), context: 'rating points' },
+      { label: 'Higher average', value: leader.title, context: leader.average.toFixed(1) + ' average rating' },
+      { label: 'Finale gap', value: (Math.max.apply(null, finales) - Math.min.apply(null, finales)).toFixed(1), context: 'rating points' }
+    ];
   }
 
   function organize_chart_data(raw){
@@ -897,7 +1061,7 @@ angular.module('TVCharts.Charts', [
           delete series[season];
         }
       }
-      var seasons_i = Object.keys(series).sort(function(e){ parseInt(e) });
+      var seasons_i = Object.keys(series).sort(function(a, b){ return parseInt(a) - parseInt(b); });
       var series_labels_i = [];
       var label_store_i = [];
       var datasets_i = [];
@@ -913,7 +1077,7 @@ angular.module('TVCharts.Charts', [
       // for each season
       var i = 0;
       seasons_i.forEach(function(s){
-        var season_ix = parseInt(s) - 1;
+        var season_ix = seasons_i.indexOf(s);
         var aired_in_season = 0;
         // for each episode
         series[s].forEach(function(e){
@@ -966,6 +1130,10 @@ angular.module('TVCharts.Charts', [
 
     chartsCtrl.series_labels = series_labels;
 
+    // Connected seasons create one continuous episode line and one distinct
+    // full-series trendline per show, which is the clearest comparison view.
+    if(raw.length > 1){ chartsCtrl.connectSeasons = true; }
+
     if(chartsCtrl.chart_title.length > 1){
       chartsCtrl.colors = getColors(chartsCtrl.chart_title.length, false);
     }else{
@@ -975,6 +1143,7 @@ angular.module('TVCharts.Charts', [
     // { season #, {title, release, ep#, rating, id}, "S##E##", "Season ##", colors}
     chartsCtrl.options_object = { seasons: seasons, ep_data: ep_data, label_store: label_store, series_labels: series_labels, colors: chartsCtrl.colors, multi: raw.length > 1 ? true : false };
     chartsCtrl.datasets = scrubDatasets(chartsCtrl.datasets.flat());
+    updateSummaryCards(raw);
     chartsCtrl.loading = false;
     chartsCtrl.showCanvas = true;
     // window.history.pushState('/abcdef', 'Title', '/' + chartsCtrl.imdbId.map(function(el){ return 'i=' + el }).join(','));

--- a/app/assets/javascripts/charts/charts.js
+++ b/app/assets/javascripts/charts/charts.js
@@ -52,11 +52,12 @@ angular.module('TVCharts.Charts', [
   chartsCtrl.labels = [];
   chartsCtrl.series_labels = [];
   chartsCtrl.chart_title = [];
+  chartsCtrl.series_meta = [];
   chartsCtrl.compType = 'norm';
   chartsCtrl.compNormType = 's-left';
   chartsCtrl.compSeasonAlign = 'left';
   chartsCtrl.compEpAlign = 'left';
-  chartsCtrl.connectSeasons = true;
+  chartsCtrl.connectSeasons = false;
   chartsCtrl.fill = false;
   chartsCtrl.focusedScale = false;
   try {
@@ -140,8 +141,33 @@ angular.module('TVCharts.Charts', [
   function detectSearchInput(){
     var imdbId = extractImdbId(chartsCtrl.search_query);
     chartsCtrl.search_is_imdb = imdbId != null;
-    chartsCtrl.search_hint = imdbId ? 'IMDb ID detected: ' + imdbId : 'Title search — year can help distinguish remakes';
+    chartsCtrl.search_hint = imdbId ? 'IMDb ID detected: ' + imdbId : 'Year can distinguish any shows that share a title';
     return imdbId;
+  }
+
+  function seriesYear(value){
+    var match = String(value || '').match(/\d{4}/);
+    return match ? match[0] : '';
+  }
+
+  function updateChartTitles(){
+    var titleCounts = {};
+    chartsCtrl.series_meta.forEach(function(meta){
+      titleCounts[meta.title] = (titleCounts[meta.title] || 0) + 1;
+    });
+    chartsCtrl.chart_title = chartsCtrl.series_meta.map(function(meta){
+      var displayTitle = meta.title;
+      if(titleCounts[meta.title] > 1 && meta.year){
+        displayTitle += ' (' + meta.year + ')';
+      }
+      return [displayTitle, 'https://www.justwatch.com/us/search?q=' + encodeURIComponent(meta.title)];
+    });
+  }
+
+  function clearSearchFields(){
+    chartsCtrl.search_query = '';
+    chartsCtrl.year = null;
+    detectSearchInput();
   }
 
   function search(add){
@@ -218,10 +244,12 @@ angular.module('TVCharts.Charts', [
       }
 
       var episodeQuery = response.data.map(function(el){ return [el.imdbID, el.Title] });
+      chartsCtrl.series_meta = response.data.map(function(el){
+        return { id: el.imdbID, title: el.Title, year: seriesYear(el.Year) };
+      });
       chartsCtrl.imdbId = episodeQuery.map(function(el){ return el[0] });
-      chartsCtrl.chart_title = episodeQuery.map(function(el){ return [el[1], "https://www.justwatch.com/us/search?q=" + encodeURI(el[1])] });
-      chartsCtrl.search_query = episodeQuery[0][1];
-      detectSearchInput();
+      updateChartTitles();
+      clearSearchFields();
       
       // get actual episode data
       episodesFactory.getEpisodesBatch(episodeQuery.join("|"))
@@ -245,6 +273,7 @@ angular.module('TVCharts.Charts', [
     var existingSeries = chartsCtrl.series_list.slice ? chartsCtrl.series_list.slice() : [];
     var existingTitles = chartsCtrl.chart_title.slice();
     var existingIds = chartsCtrl.imdbId.slice();
+    var existingMeta = chartsCtrl.series_meta.slice();
     if(!add){
       // if this isn't an additive function, start over
       chartsCtrl.chart_title = [];
@@ -252,6 +281,7 @@ angular.module('TVCharts.Charts', [
       chartsCtrl.datasets = [];
       chartsCtrl.series_list = [];
       chartsCtrl.imdbId = [];
+      chartsCtrl.series_meta = [];
       chartsCtrl.showCanvas = false;
       // destroy existing chart via angular-chart.js event
       $scope.$broadcast('chart-destroy');
@@ -267,8 +297,10 @@ angular.module('TVCharts.Charts', [
     }else{
       params = 'i=' + imdb_id;
     }
-    // set url based on params provided
-    $window.history.pushState(null, 'TV Show Trends', '/' + [params, chartsCtrl.imdbId.map(function(el){ return 'i=' + el }).join(',')].filter(function(el){ return el; }).join(','));
+    // Keep the URL in the same order as the displayed series so reloads retain
+    // the comparison order and color assignments.
+    var urlParams = add ? chartsCtrl.imdbId.map(function(el){ return 'i=' + el; }).concat([params]) : [params];
+    $window.history.pushState(null, 'TV Show Trends', '/' + urlParams.join(','));
     chartsCtrl.loading = true;
 
     // get imdb ID and clean title
@@ -281,6 +313,7 @@ angular.module('TVCharts.Charts', [
           chartsCtrl.series_list = existingSeries;
           chartsCtrl.chart_title = existingTitles;
           chartsCtrl.imdbId = existingIds;
+          chartsCtrl.series_meta = existingMeta;
         }else{
           chartsCtrl.showCanvas = false;
           chartsCtrl.series_list = [];
@@ -293,9 +326,9 @@ angular.module('TVCharts.Charts', [
       var resolvedImdbId = response.data.imdbID;
       chartsCtrl.imdbId.push(resolvedImdbId);
       var title = response.data.Title;
-      chartsCtrl.chart_title.push([title, "https://www.justwatch.com/us/search?q=" + encodeURI(title)]);
-      chartsCtrl.search_query = title;
-      detectSearchInput();
+      chartsCtrl.series_meta.push({ id: resolvedImdbId, title: title, year: seriesYear(response.data.Year) });
+      updateChartTitles();
+      clearSearchFields();
 
       // get actual episode data
       return episodesFactory.getEpisodes(resolvedImdbId, title)
@@ -312,9 +345,13 @@ angular.module('TVCharts.Charts', [
         chartsCtrl.series_list = existingSeries;
         chartsCtrl.chart_title = existingTitles;
         chartsCtrl.imdbId = existingIds;
+        chartsCtrl.series_meta = existingMeta;
       }else{
         chartsCtrl.showCanvas = false;
         chartsCtrl.series_list = [];
+        chartsCtrl.series_meta = [];
+        chartsCtrl.chart_title = [];
+        chartsCtrl.imdbId = [];
       }
       if(canvas && !add){
         canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
@@ -327,10 +364,10 @@ angular.module('TVCharts.Charts', [
     var seasons = opts['seasons'];
     var ep_data;
     if(chartsCtrl.connectSeasons){
-      var shows = [...new Set(opts['ep_data'].flat().map(function(e){ return e['Show Title']; }) )];
+      var shows = [...new Set(opts['ep_data'].flat().map(function(e){ return e['_seriesKey']; }) )];
       ep_data = [];
       opts['ep_data'].flat().forEach(function(e){
-        var arr = ep_data[shows.indexOf(e['Show Title'])];
+        var arr = ep_data[shows.indexOf(e['_seriesKey'])];
         if(!arr){
           ep_data.push([e]);
         }else{
@@ -536,7 +573,7 @@ angular.module('TVCharts.Charts', [
     }
     var series_labels;
     if(chartsCtrl.connectSeasons){
-      series_labels = [...new Set(opts['ep_data'].map(function(e){ return e[0]['Show Title']; }) )];
+      series_labels = chartsCtrl.chart_title.map(function(title){ return title[0]; });
     }else{
       series_labels = opts['series_labels'];
     }
@@ -1033,12 +1070,16 @@ angular.module('TVCharts.Charts', [
     }
 
     var averages = stats.map(function(stat){ return stat.average; });
-    var finales = stats.map(function(stat){ return stat.last; });
     var leader = stats.reduce(function(best, stat){ return stat.average > best.average ? stat : best; }, stats[0]);
+    var finaleLeader = stats.reduce(function(best, stat){ return stat.last > best.last ? stat : best; }, stats[0]);
+    var finaleTrailer = stats.reduce(function(worst, stat){ return stat.last < worst.last ? stat : worst; }, stats[0]);
+    var finaleGap = finaleLeader.last - finaleTrailer.last;
     chartsCtrl.summary_cards = [
       { label: 'Average gap', value: (Math.max.apply(null, averages) - Math.min.apply(null, averages)).toFixed(1), context: 'rating points' },
       { label: 'Higher average', value: leader.title, context: leader.average.toFixed(1) + ' average rating' },
-      { label: 'Finale gap', value: (Math.max.apply(null, finales) - Math.min.apply(null, finales)).toFixed(1), context: 'rating points' }
+      finaleGap == 0
+        ? { label: 'Finale gap', value: 'Even', context: finaleLeader.last.toFixed(1) + ' rating' }
+        : { label: 'Finale gap', value: finaleLeader.title + ' +' + finaleGap.toFixed(1), context: finaleLeader.last.toFixed(1) + ' vs. ' + finaleTrailer.last.toFixed(1) }
     ];
   }
 
@@ -1054,7 +1095,9 @@ angular.module('TVCharts.Charts', [
     chartsCtrl.datasets = [];
     chartsCtrl.series_labels = [];
     
-    raw.forEach(function(series){
+    raw.forEach(function(series, seriesIndex){
+      var seriesKey = chartsCtrl.imdbId[seriesIndex] || ('series-' + seriesIndex);
+      var displayTitle = chartsCtrl.chart_title[seriesIndex] ? chartsCtrl.chart_title[seriesIndex][0] : ('Series ' + (seriesIndex + 1));
       // scrub raw to make sure we're not trying to get null data
       for(var season in series){
         if(series[season].length == 0){
@@ -1090,9 +1133,10 @@ angular.module('TVCharts.Charts', [
 
           label_store_i.push("S" + s.padStart(2, '0') + "E" + e.Episode.padStart(2, '0'));
           // season_ix * 2 because each season has two datasets (ep_data and best fit)
-          datasets_i[season_ix * 2].push({ x: i, y: parseFloat(e['imdbRating']), type: "ep", show: e['Show Title'], season: s, episode: e.Episode });
+          datasets_i[season_ix * 2].push({ x: i, y: parseFloat(e['imdbRating']), type: "ep", show: seriesKey, showTitle: displayTitle, season: s, episode: e.Episode });
 
           e['season'] = s;
+          e['_seriesKey'] = seriesKey;
           ep_data_i[season_ix].push(e);
           i++;
           aired_in_season++;
@@ -1103,7 +1147,7 @@ angular.module('TVCharts.Charts', [
         // leave series_labels longer than the dataset list and desync the color
         // indexing in set_dataset_override (colors[undefined] -> crash).
         if(aired_in_season > 0){
-          series_labels_i.push("Season " + s.padStart(2, '0'));
+          series_labels_i.push((raw.length > 1 ? displayTitle + ' · ' : '') + "Season " + s.padStart(2, '0'));
         }
       });
       
@@ -1129,10 +1173,6 @@ angular.module('TVCharts.Charts', [
     });
 
     chartsCtrl.series_labels = series_labels;
-
-    // Connected seasons create one continuous episode line and one distinct
-    // full-series trendline per show, which is the clearest comparison view.
-    if(raw.length > 1){ chartsCtrl.connectSeasons = true; }
 
     if(chartsCtrl.chart_title.length > 1){
       chartsCtrl.colors = getColors(chartsCtrl.chart_title.length, false);

--- a/app/assets/javascripts/charts/charts.tmpl.html.erb
+++ b/app/assets/javascripts/charts/charts.tmpl.html.erb
@@ -1,93 +1,182 @@
-<div style="margin-left: 20px; margin-top: 20px; margin-right: 20px">
-  <div style="display: flex; justify-content: space-between; align-items: flex-start;">
-    <h1 style="margin-bottom: 20px">TV Show Trends</h1>
-    <md-button class="md-icon-button" ng-click="chartsCtrl.showHelp($event)" aria-label="Help" style="margin-top: 5px;">
-      <i class="material-icons">help_outline</i>
-    </md-button>
-  </div>
-  <h5></h5>
-  <form name="get_data_form">
-    <md-input-container>
-      <input ng-keyup="$event.keyCode == 13 && chartsCtrl.get_trend(chartsCtrl.series, chartsCtrl.year, chartsCtrl.imdb_id)" type="text" ng-model="chartsCtrl.imdb_id" placeholder="IMDb ID (if no title)" ng-required="!chartsCtrl.series">
-    </md-input-container>
-    OR
-    <br />
-    <md-input-container>
-      <input ng-keyup="$event.keyCode == 13 && chartsCtrl.get_trend(chartsCtrl.series, chartsCtrl.year, chartsCtrl.imdb_id)" type="text" ng-model="chartsCtrl.series" placeholder="Show Title (if no IMDb ID)" ng-required="!chartsCtrl.imdb_id">
-    </md-input-container>
-    <md-input-container>
-      <input ng-keyup="$event.keyCode == 13 && chartsCtrl.get_trend(chartsCtrl.series, chartsCtrl.year, chartsCtrl.imdb_id)" type="text" ng-model="chartsCtrl.year" placeholder="Year (Optional)">
-    </md-input-container>
+<div class="tv-trends-page" ng-class="{'tv-theme-dark': chartsCtrl.darkMode, 'tv-theme-light': !chartsCtrl.darkMode}">
+  <header class="tv-page-header">
+    <div class="tv-brand">
+      <span class="tv-brand-icon" aria-hidden="true"><i class="material-icons">movie</i></span>
+      <div>
+        <h1>TV Show Trends</h1>
+        <p>Explore how episode ratings change over time.</p>
+      </div>
+    </div>
+    <div class="tv-header-actions">
+      <md-button class="md-icon-button" ng-click="chartsCtrl.showHelp($event)" aria-label="About TV Show Trends">
+        <i class="material-icons">help_outline</i>
+      </md-button>
+      <md-button class="tv-theme-toggle" ng-click="chartsCtrl.toggleTheme()" aria-label="Switch to {{ chartsCtrl.darkMode ? 'light' : 'dark' }} mode">
+        <i class="material-icons" aria-hidden="true">{{ chartsCtrl.darkMode ? 'light_mode' : 'dark_mode' }}</i>
+        <span>{{ chartsCtrl.darkMode ? 'Light mode' : 'Dark mode' }}</span>
+      </md-button>
+    </div>
+  </header>
 
-    <br />
-  </form>
-  <md-button mat-button class="md-raised md-primary" ng-disabled="!get_data_form.$valid" type="button" ng-click="chartsCtrl.get_trend(chartsCtrl.series, chartsCtrl.year, chartsCtrl.imdb_id, false)">Individual</md-button>
-  <md-button mat-button class="md-raised md-accent" ng-disabled="!get_data_form.$valid || !chartsCtrl.series_list.length > 0" type="button" ng-click="chartsCtrl.get_trend(chartsCtrl.series, chartsCtrl.year, chartsCtrl.imdb_id, true)">Add to compare</md-button>
-  
-  <div layout="row" gutterSize="20px">
-    <div class="opts-container">
-      <label>Display options</label>
-      <md-switch ng-change="chartsCtrl.prevent_empty_switch('episodes'); chartsCtrl.set_dataset_override(chartsCtrl.options_object, chartsCtrl.chart_title.length > 1)" ng-model="chartsCtrl.episode_data" aria-label="Episode Data">
-        Show Episode Data
-      </md-switch>
-      <md-switch ng-change="chartsCtrl.prevent_empty_switch('trends'); chartsCtrl.set_dataset_override(chartsCtrl.options_object, chartsCtrl.chart_title.length > 1)" ng-model="chartsCtrl.trends" aria-label="Trend Data">
-        Show Trendlines
-      </md-switch>
-      <md-switch ng-change="chartsCtrl.set_options(chartsCtrl.options_object)" ng-model="chartsCtrl.fill" aria-label="Area Chart">
-        Area Chart
-      </md-switch>
-      <md-switch ng-change="chartsCtrl.setOptSelect(); chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())" ng-model="chartsCtrl.connectSeasons" aria-label="Connect Seasons">
-        Connect Seasons
-      </md-switch>
-    </div>
-    <div ng-show="chartsCtrl.series_list.length > 1" class="opts-container">
-      <div id="comp-chart-options">
-        <label id="multi-chart-type">Select display style</label>
-        <md-radio-group aria-label="Select display style" ng-model="chartsCtrl.compType" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
-          <md-radio-button value="norm">Normalize</md-radio-button>
-          <md-radio-button value="s-align" ng-show="!chartsCtrl.connectSeasons">Align Seasons</md-radio-button>
-          <md-radio-button value="raw">Raw</md-radio-button>
-        </md-radio-group>
+  <section class="tv-card tv-search-card" aria-label="Find a TV series">
+    <form name="get_data_form" ng-submit="chartsCtrl.search(false)" novalidate>
+      <div class="tv-search-grid">
+        <md-input-container class="tv-search-input">
+          <label>Show title or IMDb ID</label>
+          <input type="text"
+                 name="series_query"
+                 ng-model="chartsCtrl.search_query"
+                 ng-change="chartsCtrl.detectSearchInput()"
+                 autocomplete="off"
+                 required>
+        </md-input-container>
+
+        <md-input-container class="tv-year-input" ng-if="!chartsCtrl.search_is_imdb">
+          <label>Year (optional)</label>
+          <input type="number" name="series_year" ng-model="chartsCtrl.year" min="1900" max="2100">
+        </md-input-container>
+
+        <md-button class="md-raised md-primary tv-view-button"
+                   type="submit"
+                   ng-disabled="get_data_form.$invalid || chartsCtrl.loading">
+          <i class="material-icons" aria-hidden="true">search</i>
+          View chart
+        </md-button>
       </div>
-    </div>
-    <div ng-show="chartsCtrl.series_list.length > 1 && chartsCtrl.compType == 'norm' && !chartsCtrl.connectSeasons" class="opts-container">
-      <div id="norm-opts">
-        <label id="multi-chart-type">Select Normalization style</label>
-        <md-radio-group aria-label="Select display style" ng-model="chartsCtrl.compNormType" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
-          <md-radio-button value="s-left">Season, Left-Aligned</md-radio-button>
-          <md-radio-button value="s-right">Season, Right-Aligned</md-radio-button>
-          <md-radio-button value="full">Full Series</md-radio-button>
-        </md-radio-group>
+
+      <div class="tv-search-footer">
+        <span class="tv-search-hint" ng-class="{'is-detected': chartsCtrl.search_is_imdb}">
+          <i class="material-icons" aria-hidden="true">{{ chartsCtrl.search_is_imdb ? 'check_circle' : 'info_outline' }}</i>
+          {{ chartsCtrl.search_hint }}
+        </span>
+        <md-button class="tv-compare-button"
+                   type="button"
+                   ng-show="chartsCtrl.series_list.length > 0"
+                   ng-disabled="get_data_form.$invalid || chartsCtrl.loading"
+                   ng-click="chartsCtrl.search(true)">
+          <i class="material-icons" aria-hidden="true">add</i>
+          Add comparison
+        </md-button>
       </div>
-    </div>
-    <div ng-show="chartsCtrl.series_list.length > 1 && chartsCtrl.compType != 'norm' && !(chartsCtrl.connectSeasons && chartsCtrl.compType == 's-align')" class="opts-container">
-      <div id="align-eps">
-        <label id="multi-chart-type">Select episode alignment</label>
-        <md-radio-group aria-label="Select episode alignment" ng-model="chartsCtrl.compEpAlign" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
-          <md-radio-button value="left">Left</md-radio-button>
-          <md-radio-button value="right">Right</md-radio-button>
-        </md-radio-group>
-      </div>
-    </div>
-    <div ng-show="chartsCtrl.series_list.length > 1 && chartsCtrl.compType == 's-align' && !chartsCtrl.connectSeasons" class="opts-container">
-      <div id="align-seasons">
-        <label id="multi-chart-type">Select season alignment</label>
-        <md-radio-group aria-label="Select episode alignment" ng-model="chartsCtrl.compSeasonAlign" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
-          <md-radio-button value="left">Left</md-radio-button>
-          <md-radio-button value="right">Right</md-radio-button>
-        </md-radio-group>
-      </div>
+    </form>
+  </section>
+
+  <div class="tv-error" role="alert" ng-show="chartsCtrl.error_message">
+    <i class="material-icons" aria-hidden="true">error_outline</i>
+    <span>{{ chartsCtrl.error_message }}</span>
+  </div>
+
+  <div class="tv-loading" aria-live="polite" ng-show="chartsCtrl.loading">
+    <img src="<%= image_url('loading.gif') %>" alt="">
+    <div>
+      <strong>Collecting series information</strong>
+      <span>New searches can take a little longer while episode data is cached.</span>
     </div>
   </div>
 
-  <br><br>
-  <div style="width: 90%; text-align: center">
-   <div class="chart-title"><span ng-repeat="title in chartsCtrl.chart_title track by $index"><b style="text-decoration: {{ chartsCtrl.series_list.length > 1 ? 'underline' : 'none' }}; text-decoration-color: {{ chartsCtrl.colors[$index] }}">{{ title[0]}} <a ng-show="chartsCtrl.series_list.length > 0" href="{{ title[1] }}" style="color: #5555CC !important" target="_blank"> <md-tooltip md-direction="right">See viewing options</md-tooltip><i class="material-icons">open_in_new</i></a></b></span></div>
-    <div class="chart-subtitle" ng-show="chartsCtrl.chart_title.length > 0"><i>(click datapoint to open episode info)</i></div>
-    <div ng-show="chartsCtrl.loading">
-      <p><i style="color: #E98181"><b>Collecting series information....</b></i></p><br>
-      <img src="<%= image_url('loading.gif') %>" />
+  <main class="tv-results" ng-show="chartsCtrl.showCanvas">
+    <div class="tv-results-heading">
+      <div>
+        <div class="tv-chart-title">
+          <span class="tv-title-item"
+                ng-repeat="title in chartsCtrl.chart_title track by $index"
+                ng-style="{'border-color': chartsCtrl.colors[$index]}">
+            {{ title[0] }}
+            <a ng-href="{{ title[1] }}" target="_blank" rel="noopener" aria-label="Find where to watch {{ title[0] }}">
+              <i class="material-icons" aria-hidden="true">open_in_new</i>
+            </a>
+          </span>
+        </div>
+        <p class="tv-chart-subtitle">Select an episode point to open its IMDb page.</p>
+      </div>
+      <div class="tv-scale-badge">Scale {{ chartsCtrl.rating_axis_min }}–10</div>
     </div>
-    <canvas ng-show="chartsCtrl.showCanvas" width="900" id="chart" class="chart chart-line" chart-data="chartsCtrl.datasets" chart-labels="chartsCtrl.labels" chart-options="chartsCtrl.options" chart-series="chartsCtrl.series_labels" chart-dataset-override="chartsCtrl.dataset_override">
-  </div>
+
+    <section class="tv-chart-controls" aria-label="Chart display options">
+      <div class="tv-switches">
+        <md-switch ng-change="chartsCtrl.prevent_empty_switch('episodes'); chartsCtrl.set_dataset_override(chartsCtrl.options_object, chartsCtrl.chart_title.length > 1)"
+                   ng-model="chartsCtrl.episode_data"
+                   aria-label="Show episode ratings">
+          Episodes
+        </md-switch>
+        <md-switch ng-change="chartsCtrl.prevent_empty_switch('trends'); chartsCtrl.set_dataset_override(chartsCtrl.options_object, chartsCtrl.chart_title.length > 1)"
+                   ng-model="chartsCtrl.trends"
+                   aria-label="Show trendlines">
+          Trendlines
+        </md-switch>
+        <md-switch ng-change="chartsCtrl.set_options(chartsCtrl.options_object); chartsCtrl.set_dataset_override(chartsCtrl.chart_title.length > 1)"
+                   ng-model="chartsCtrl.fill"
+                   aria-label="Fill area below episode lines">
+          Area fill
+        </md-switch>
+        <md-switch ng-change="chartsCtrl.set_options(chartsCtrl.options_object)"
+                   ng-model="chartsCtrl.focusedScale"
+                   aria-label="Focus the rating axis around the displayed ratings">
+          Focused Y-axis
+        </md-switch>
+        <md-switch ng-change="chartsCtrl.setOptSelect(); chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())"
+                   ng-model="chartsCtrl.connectSeasons"
+                   aria-label="Connect seasons into full-series lines">
+          Full-series lines
+        </md-switch>
+      </div>
+
+      <div class="tv-comparison-controls" ng-show="chartsCtrl.series_list.length > 1">
+        <md-input-container>
+          <label>Compare by</label>
+          <md-select ng-model="chartsCtrl.compType" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
+            <md-option value="norm">Normalized progress</md-option>
+            <md-option value="s-align" ng-if="!chartsCtrl.connectSeasons">Aligned seasons</md-option>
+            <md-option value="raw">Episode number</md-option>
+          </md-select>
+        </md-input-container>
+
+        <md-input-container ng-show="chartsCtrl.compType == 'norm' && !chartsCtrl.connectSeasons">
+          <label>Normalize from</label>
+          <md-select ng-model="chartsCtrl.compNormType" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
+            <md-option value="s-left">First season</md-option>
+            <md-option value="s-right">Final season</md-option>
+            <md-option value="full">Full series</md-option>
+          </md-select>
+        </md-input-container>
+
+        <md-input-container ng-show="chartsCtrl.compType != 'norm' && !(chartsCtrl.connectSeasons && chartsCtrl.compType == 's-align')">
+          <label>Episode alignment</label>
+          <md-select ng-model="chartsCtrl.compEpAlign" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
+            <md-option value="left">From the beginning</md-option>
+            <md-option value="right">From the end</md-option>
+          </md-select>
+        </md-input-container>
+
+        <md-input-container ng-show="chartsCtrl.compType == 's-align' && !chartsCtrl.connectSeasons">
+          <label>Season alignment</label>
+          <md-select ng-model="chartsCtrl.compSeasonAlign" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
+            <md-option value="left">First season</md-option>
+            <md-option value="right">Final season</md-option>
+          </md-select>
+        </md-input-container>
+      </div>
+    </section>
+
+    <section class="tv-chart-stage" aria-label="Episode rating chart">
+      <canvas id="chart"
+              class="chart chart-line"
+              height="420"
+              chart-data="chartsCtrl.datasets"
+              chart-labels="chartsCtrl.labels"
+              chart-options="chartsCtrl.options"
+              chart-series="chartsCtrl.series_labels"
+              chart-dataset-override="chartsCtrl.dataset_override">
+        Episode ratings chart for {{ chartsCtrl.chart_title[0][0] }}.
+      </canvas>
+    </section>
+
+    <section class="tv-summary-grid" aria-label="Rating summary" ng-show="chartsCtrl.summary_cards.length">
+      <article class="tv-card tv-summary-card" ng-repeat="card in chartsCtrl.summary_cards track by $index">
+        <span>{{ card.label }}</span>
+        <strong>{{ card.value }}</strong>
+        <small>{{ card.context }}</small>
+      </article>
+    </section>
+  </main>
 </div>

--- a/app/assets/javascripts/charts/charts.tmpl.html.erb
+++ b/app/assets/javascripts/charts/charts.tmpl.html.erb
@@ -36,12 +36,22 @@
           <input type="number" name="series_year" ng-model="chartsCtrl.year" min="1900" max="2100">
         </md-input-container>
 
-        <md-button class="md-raised md-primary tv-view-button"
-                   type="submit"
-                   ng-disabled="get_data_form.$invalid || chartsCtrl.loading">
-          <i class="material-icons" aria-hidden="true">search</i>
-          View chart
-        </md-button>
+        <div class="tv-search-actions">
+          <md-button class="md-raised md-primary tv-view-button"
+                     type="submit"
+                     ng-disabled="get_data_form.$invalid || chartsCtrl.loading">
+            <i class="material-icons" aria-hidden="true">search</i>
+            {{ chartsCtrl.series_list.length > 0 ? 'Replace chart' : 'View chart' }}
+          </md-button>
+          <md-button class="tv-compare-button"
+                     type="button"
+                     ng-show="chartsCtrl.series_list.length > 0"
+                     ng-disabled="get_data_form.$invalid || chartsCtrl.loading"
+                     ng-click="chartsCtrl.search(true)">
+            <i class="material-icons" aria-hidden="true">add_chart</i>
+            Compare entered show
+          </md-button>
+        </div>
       </div>
 
       <div class="tv-search-footer">
@@ -49,14 +59,6 @@
           <i class="material-icons" aria-hidden="true">{{ chartsCtrl.search_is_imdb ? 'check_circle' : 'info_outline' }}</i>
           {{ chartsCtrl.search_hint }}
         </span>
-        <md-button class="tv-compare-button"
-                   type="button"
-                   ng-show="chartsCtrl.series_list.length > 0"
-                   ng-disabled="get_data_form.$invalid || chartsCtrl.loading"
-                   ng-click="chartsCtrl.search(true)">
-          <i class="material-icons" aria-hidden="true">add</i>
-          Add comparison
-        </md-button>
       </div>
     </form>
   </section>
@@ -78,13 +80,13 @@
     <div class="tv-results-heading">
       <div>
         <div class="tv-chart-title">
-          <span class="tv-title-item"
-                ng-repeat="title in chartsCtrl.chart_title track by $index"
-                ng-style="{'border-color': chartsCtrl.colors[$index]}">
-            {{ title[0] }}
-            <a ng-href="{{ title[1] }}" target="_blank" rel="noopener" aria-label="Find where to watch {{ title[0] }}">
-              <i class="material-icons" aria-hidden="true">open_in_new</i>
-            </a>
+          <span class="tv-title-item" ng-repeat="title in chartsCtrl.chart_title track by $index">
+            <span class="tv-title-name" ng-style="{'border-color': chartsCtrl.colors[$index]}">
+              {{ title[0] }}
+              <a ng-href="{{ title[1] }}" target="_blank" rel="noopener" aria-label="Find where to watch {{ title[0] }}">
+                <i class="material-icons" aria-hidden="true">open_in_new</i>
+              </a>
+            </span>
           </span>
         </div>
         <p class="tv-chart-subtitle">Select an episode point to open its IMDb page.</p>
@@ -117,44 +119,44 @@
         <md-switch ng-change="chartsCtrl.setOptSelect(); chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())"
                    ng-model="chartsCtrl.connectSeasons"
                    aria-label="Connect seasons into full-series lines">
-          Full-series lines
+          Combine seasons
         </md-switch>
       </div>
 
       <div class="tv-comparison-controls" ng-show="chartsCtrl.series_list.length > 1">
-        <md-input-container>
-          <label>Compare by</label>
-          <md-select ng-model="chartsCtrl.compType" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
-            <md-option value="norm">Normalized progress</md-option>
-            <md-option value="s-align" ng-if="!chartsCtrl.connectSeasons">Aligned seasons</md-option>
-            <md-option value="raw">Episode number</md-option>
-          </md-select>
-        </md-input-container>
+        <div class="tv-radio-control">
+          <span class="tv-control-label">Align shows</span>
+          <md-radio-group class="tv-radio-cluster" ng-model="chartsCtrl.compType" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
+            <md-radio-button value="norm">By progress</md-radio-button>
+            <md-radio-button value="s-align" ng-if="!chartsCtrl.connectSeasons">By season</md-radio-button>
+            <md-radio-button value="raw">By episode count</md-radio-button>
+          </md-radio-group>
+        </div>
 
-        <md-input-container ng-show="chartsCtrl.compType == 'norm' && !chartsCtrl.connectSeasons">
-          <label>Normalize from</label>
-          <md-select ng-model="chartsCtrl.compNormType" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
-            <md-option value="s-left">First season</md-option>
-            <md-option value="s-right">Final season</md-option>
-            <md-option value="full">Full series</md-option>
-          </md-select>
-        </md-input-container>
+        <div class="tv-radio-control" ng-show="chartsCtrl.compType == 'norm' && !chartsCtrl.connectSeasons">
+          <span class="tv-control-label">Progress reference</span>
+          <md-radio-group class="tv-radio-cluster" ng-model="chartsCtrl.compNormType" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
+            <md-radio-button value="s-left">Season starts</md-radio-button>
+            <md-radio-button value="s-right">Season ends</md-radio-button>
+            <md-radio-button value="full">Full series</md-radio-button>
+          </md-radio-group>
+        </div>
 
-        <md-input-container ng-show="chartsCtrl.compType != 'norm' && !(chartsCtrl.connectSeasons && chartsCtrl.compType == 's-align')">
-          <label>Episode alignment</label>
-          <md-select ng-model="chartsCtrl.compEpAlign" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
-            <md-option value="left">From the beginning</md-option>
-            <md-option value="right">From the end</md-option>
-          </md-select>
-        </md-input-container>
+        <div class="tv-radio-control" ng-show="chartsCtrl.compType != 'norm' && !(chartsCtrl.connectSeasons && chartsCtrl.compType == 's-align')">
+          <span class="tv-control-label">Episodes line up</span>
+          <md-radio-group class="tv-radio-cluster" ng-model="chartsCtrl.compEpAlign" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
+            <md-radio-button value="left">At start</md-radio-button>
+            <md-radio-button value="right">At end</md-radio-button>
+          </md-radio-group>
+        </div>
 
-        <md-input-container ng-show="chartsCtrl.compType == 's-align' && !chartsCtrl.connectSeasons">
-          <label>Season alignment</label>
-          <md-select ng-model="chartsCtrl.compSeasonAlign" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
-            <md-option value="left">First season</md-option>
-            <md-option value="right">Final season</md-option>
-          </md-select>
-        </md-input-container>
+        <div class="tv-radio-control" ng-show="chartsCtrl.compType == 's-align' && !chartsCtrl.connectSeasons">
+          <span class="tv-control-label">Seasons line up</span>
+          <md-radio-group class="tv-radio-cluster" ng-model="chartsCtrl.compSeasonAlign" ng-change="chartsCtrl.scrubDatasets(chartsCtrl.datasets.flat())">
+            <md-radio-button value="left">First seasons</md-radio-button>
+            <md-radio-button value="right">Final seasons</md-radio-button>
+          </md-radio-group>
+        </div>
       </div>
     </section>
 

--- a/app/assets/javascripts/services/episodes.js
+++ b/app/assets/javascripts/services/episodes.js
@@ -8,7 +8,7 @@
     }
 
     factory.getEpisodes = function(imdb_id, title){
-      return $http.get(bustCache("api/episodes/" + imdb_id + "?title=" + title));
+      return $http.get(bustCache("api/episodes/" + imdb_id + "?title=" + encodeURIComponent(title)));
     }
 
     factory.getEpisodesBatch = function(params){

--- a/app/assets/stylesheets/custom_styling.css.scss
+++ b/app/assets/stylesheets/custom_styling.css.scss
@@ -352,10 +352,11 @@ md-switch {
   --tv-text: #172033;
   --tv-muted: #657188;
   --tv-primary: #2563eb;
+  --tv-link: #1d4ed8;
   --tv-accent: #0f766e;
   --tv-error: #b42318;
   box-sizing: border-box;
-  min-height: 100vh;
+  min-height: calc(100vh - 50px);
   padding: 28px clamp(16px, 3vw, 44px) 52px;
   background: var(--tv-bg);
   color: var(--tv-text);
@@ -371,6 +372,7 @@ md-switch {
   --tv-text: #f4f7fb;
   --tv-muted: #9aa7bd;
   --tv-primary: #60a5fa;
+  --tv-link: #93c5fd;
   --tv-accent: #5eead4;
   --tv-error: #fda29b;
 }
@@ -477,7 +479,7 @@ md-switch {
 
 .tv-search-grid {
   display: grid;
-  grid-template-columns: minmax(260px, 1fr) minmax(130px, 210px) auto;
+  grid-template-columns: minmax(260px, 1fr) minmax(130px, 210px) minmax(220px, auto);
   align-items: center;
   gap: 16px;
 }
@@ -525,8 +527,16 @@ md-switch {
   text-transform: none;
 }
 
+.tv-search-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
 .tv-search-footer {
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 12px;
   min-height: 38px;
   margin-top: 4px;
@@ -553,7 +563,9 @@ md-switch {
 
 .tv-trends-page .tv-compare-button {
   margin: 0;
-  color: var(--tv-primary);
+  color: var(--tv-link) !important;
+  border: 1px solid var(--tv-border);
+  border-radius: 8px;
   text-transform: none;
 }
 
@@ -615,8 +627,9 @@ md-switch {
   line-height: 1.15;
 }
 
-.tv-title-item {
-  border-bottom: 4px solid var(--series-color, transparent);
+.tv-title-name {
+  display: inline-block;
+  border-bottom: 4px solid transparent;
 }
 
 .tv-title-item:not(:last-child):after {
@@ -626,8 +639,13 @@ md-switch {
 }
 
 .tv-title-item a {
-  color: var(--tv-primary);
+  color: var(--tv-link) !important;
   text-decoration: none;
+}
+
+.tv-title-item a:hover,
+.tv-title-item a:focus {
+  color: var(--tv-link) !important;
 }
 
 .tv-title-item .material-icons {
@@ -672,13 +690,52 @@ md-switch {
 }
 
 .tv-comparison-controls {
-  align-items: flex-start;
-  gap: 14px;
+  align-items: stretch;
+  width: 100%;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: 12px;
+  border-top: 1px solid var(--tv-border);
+}
+
+.tv-radio-control {
+  display: grid;
+  gap: 7px;
+}
+
+.tv-control-label {
+  color: var(--tv-muted);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.tv-radio-cluster {
+  display: flex;
+  align-items: center;
+  gap: 8px 18px;
   flex-wrap: wrap;
 }
 
-.tv-comparison-controls md-input-container {
-  min-width: 160px;
+.tv-radio-cluster md-radio-button {
+  margin: 0;
+}
+
+.tv-trends-page .tv-radio-cluster .md-label {
+  color: var(--tv-text);
+}
+
+.tv-trends-page .tv-radio-cluster md-radio-button .md-off {
+  border-color: var(--tv-muted);
+}
+
+.tv-trends-page .tv-radio-cluster md-radio-button.md-checked .md-off {
+  border-color: var(--tv-primary);
+}
+
+.tv-trends-page .tv-radio-cluster md-radio-button.md-checked .md-on {
+  background-color: var(--tv-primary);
 }
 
 .tv-chart-stage {
@@ -744,14 +801,23 @@ md-switch {
     width: 100%;
   }
 
+  .tv-search-actions {
+    align-items: stretch;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .tv-trends-page .tv-compare-button {
+    width: 100%;
+  }
+
   .tv-search-footer {
     align-items: flex-start;
     flex-direction: column;
     margin-top: 10px;
   }
 
-  .tv-chart-controls,
-  .tv-comparison-controls {
+  .tv-chart-controls {
     align-items: stretch;
     flex-direction: column;
   }
@@ -761,8 +827,9 @@ md-switch {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .tv-comparison-controls md-input-container {
-    width: 100% !important;
+  .tv-radio-cluster {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .tv-chart-stage {

--- a/app/assets/stylesheets/custom_styling.css.scss
+++ b/app/assets/stylesheets/custom_styling.css.scss
@@ -788,6 +788,14 @@ md-switch {
     align-items: flex-start;
   }
 
+  .tv-results-heading {
+    flex-direction: column;
+  }
+
+  .tv-chart-title {
+    width: 100%;
+  }
+
   .tv-theme-toggle span {
     display: none;
   }

--- a/app/assets/stylesheets/custom_styling.css.scss
+++ b/app/assets/stylesheets/custom_styling.css.scss
@@ -336,33 +336,462 @@ md-content.md-default-theme, md-content, md-content {
 /**********************
 * Chart Options *
 **********************/
-.chart-title{
-  font-size: 48px;
-  line-height: 50px;
-  font-family: 'Roboto' !important;
-  color: rgba(50,50,50,.8);
-}
-.chart-subtitle{
-  color: rgba(50,50,50,.8);
-  font-size: 12px;
-}
-/* delimiter for title(s) */
-.chart-title span:not(:last-child):after {
-	content: " vs. ";
-}
-
 label {
-	font-weight: 700;
+  font-weight: 700;
 }
 
 md-switch {
-	margin-top: 0px !important;
+  margin-top: 0 !important;
 }
 
-.opts-container {
-	margin-left: 10px;
-	margin-right: 10px;
-	width: 250px;
+.tv-trends-page {
+  --tv-bg: #f4f7fb;
+  --tv-surface: #ffffff;
+  --tv-elevated: #f8fafc;
+  --tv-border: #dbe3ee;
+  --tv-text: #172033;
+  --tv-muted: #657188;
+  --tv-primary: #2563eb;
+  --tv-accent: #0f766e;
+  --tv-error: #b42318;
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 28px clamp(16px, 3vw, 44px) 52px;
+  background: var(--tv-bg);
+  color: var(--tv-text);
+  font-family: 'Roboto', sans-serif;
+  transition: background-color 180ms ease, color 180ms ease;
+}
+
+.tv-trends-page.tv-theme-dark {
+  --tv-bg: #0b1120;
+  --tv-surface: #111827;
+  --tv-elevated: #172033;
+  --tv-border: #2a3850;
+  --tv-text: #f4f7fb;
+  --tv-muted: #9aa7bd;
+  --tv-primary: #60a5fa;
+  --tv-accent: #5eead4;
+  --tv-error: #fda29b;
+}
+
+.tv-trends-page *,
+.tv-trends-page *:before,
+.tv-trends-page *:after {
+  box-sizing: border-box;
+}
+
+.tv-page-header,
+.tv-search-footer,
+.tv-results-heading,
+.tv-chart-controls,
+.tv-header-actions,
+.tv-switches,
+.tv-comparison-controls {
+  display: flex;
+  align-items: center;
+}
+
+.tv-page-header {
+  justify-content: space-between;
+  gap: 20px;
+  max-width: 1480px;
+  margin: 0 auto 22px;
+}
+
+.tv-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.tv-brand-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  color: #ffffff;
+  background: var(--tv-primary);
+}
+
+.tv-brand h1 {
+  margin: 0;
+  color: var(--tv-text);
+  font-size: clamp(25px, 3vw, 36px);
+  font-weight: 500;
+  line-height: 1.15;
+}
+
+.tv-brand p {
+  margin: 4px 0 0;
+  color: var(--tv-muted);
+  font-size: 14px;
+}
+
+.tv-header-actions {
+  gap: 4px;
+}
+
+.tv-trends-page .tv-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: auto;
+  margin: 0;
+  padding: 0 12px;
+  color: var(--tv-text);
+  border: 1px solid var(--tv-border);
+  border-radius: 8px;
+  text-transform: none;
+}
+
+.tv-trends-page .md-icon-button {
+  color: var(--tv-muted);
+}
+
+.tv-card {
+  background: var(--tv-surface);
+  border: 1px solid var(--tv-border);
+  border-radius: 14px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+.tv-theme-dark .tv-card {
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.2);
+}
+
+.tv-search-card,
+.tv-results,
+.tv-loading,
+.tv-error {
+  max-width: 1480px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.tv-search-card {
+  padding: 18px 20px 14px;
+}
+
+.tv-search-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(130px, 210px) auto;
+  align-items: center;
+  gap: 16px;
+}
+
+.tv-trends-page md-input-container {
+  width: auto !important;
+  min-width: 0;
+  margin: 10px 0 0;
+}
+
+.tv-trends-page md-input-container label,
+.tv-trends-page md-input-container .md-input,
+.tv-trends-page md-input-container md-select,
+.tv-trends-page .md-select-value,
+.tv-trends-page .md-select-icon {
+  color: var(--tv-text);
+}
+
+.tv-trends-page md-input-container .md-input,
+.tv-trends-page .md-select-value {
+  border-color: var(--tv-border);
+}
+
+.tv-trends-page md-input-container:not(.md-input-invalid).md-input-focused label,
+.tv-trends-page md-input-container:not(.md-input-invalid).md-input-has-value label {
+  color: var(--tv-primary);
+}
+
+.tv-trends-page md-input-container:not(.md-input-invalid).md-input-focused .md-input,
+.tv-trends-page md-input-container:not(.md-input-invalid).md-input-focused .md-select-value {
+  border-color: var(--tv-primary);
+}
+
+.tv-trends-page .tv-view-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-width: 136px;
+  min-height: 44px;
+  margin: 0;
+  color: #ffffff !important;
+  background: var(--tv-primary) !important;
+  border-radius: 8px;
+  text-transform: none;
+}
+
+.tv-search-footer {
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 38px;
+  margin-top: 4px;
+}
+
+.tv-search-hint,
+.tv-trends-page .tv-compare-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--tv-muted);
+  font-size: 13px;
+}
+
+.tv-search-hint .material-icons,
+.tv-trends-page .tv-compare-button .material-icons,
+.tv-trends-page .tv-view-button .material-icons {
+  font-size: 18px;
+}
+
+.tv-search-hint.is-detected {
+  color: var(--tv-accent);
+}
+
+.tv-trends-page .tv-compare-button {
+  margin: 0;
+  color: var(--tv-primary);
+  text-transform: none;
+}
+
+.tv-error,
+.tv-loading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 14px;
+  padding: 14px 16px;
+  border-radius: 10px;
+}
+
+.tv-error {
+  color: var(--tv-error);
+  background: color-mix(in srgb, var(--tv-error) 10%, var(--tv-surface));
+  border: 1px solid color-mix(in srgb, var(--tv-error) 28%, var(--tv-border));
+}
+
+.tv-loading {
+  color: var(--tv-text);
+  background: var(--tv-surface);
+  border: 1px solid var(--tv-border);
+}
+
+.tv-loading img {
+  width: 42px;
+  height: 42px;
+}
+
+.tv-loading div {
+  display: grid;
+  gap: 3px;
+}
+
+.tv-loading span {
+  color: var(--tv-muted);
+  font-size: 13px;
+}
+
+.tv-results {
+  margin-top: 24px;
+}
+
+.tv-results-heading {
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 14px;
+}
+
+.tv-chart-title {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--tv-text);
+  font-size: clamp(26px, 4vw, 46px);
+  font-weight: 500;
+  line-height: 1.15;
+}
+
+.tv-title-item {
+  border-bottom: 4px solid var(--series-color, transparent);
+}
+
+.tv-title-item:not(:last-child):after {
+  content: " vs.";
+  color: var(--tv-muted);
+  border: 0;
+}
+
+.tv-title-item a {
+  color: var(--tv-primary);
+  text-decoration: none;
+}
+
+.tv-title-item .material-icons {
+  font-size: 0.55em;
+}
+
+.tv-chart-subtitle {
+  margin: 6px 0 0;
+  color: var(--tv-muted);
+  font-size: 13px;
+}
+
+.tv-scale-badge {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  color: var(--tv-muted);
+  background: var(--tv-elevated);
+  border: 1px solid var(--tv-border);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.tv-chart-controls {
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  padding: 12px 16px;
+  background: var(--tv-surface);
+  border: 1px solid var(--tv-border);
+  border-radius: 12px 12px 0 0;
+}
+
+.tv-switches {
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.tv-trends-page md-switch {
+  margin: 0 !important;
+  color: var(--tv-text);
+}
+
+.tv-comparison-controls {
+  align-items: flex-start;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.tv-comparison-controls md-input-container {
+  min-width: 160px;
+}
+
+.tv-chart-stage {
+  height: clamp(360px, 52vw, 620px);
+  padding: 18px 12px 8px;
+  background: var(--tv-surface);
+  border: 1px solid var(--tv-border);
+  border-top: 0;
+  border-radius: 0 0 12px 12px;
+}
+
+.tv-chart-stage canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.tv-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.tv-summary-card {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 16px;
+}
+
+.tv-summary-card span,
+.tv-summary-card small {
+  color: var(--tv-muted);
+}
+
+.tv-summary-card strong {
+  overflow-wrap: anywhere;
+  color: var(--tv-text);
+  font-size: clamp(20px, 2.5vw, 30px);
+  font-weight: 500;
+}
+
+@media (max-width: 760px) {
+  .tv-trends-page {
+    padding: 18px 12px 38px;
+  }
+
+  .tv-page-header,
+  .tv-results-heading {
+    align-items: flex-start;
+  }
+
+  .tv-theme-toggle span {
+    display: none;
+  }
+
+  .tv-search-grid {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+
+  .tv-trends-page .tv-view-button {
+    width: 100%;
+  }
+
+  .tv-search-footer {
+    align-items: flex-start;
+    flex-direction: column;
+    margin-top: 10px;
+  }
+
+  .tv-chart-controls,
+  .tv-comparison-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .tv-switches {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tv-comparison-controls md-input-container {
+    width: 100% !important;
+  }
+
+  .tv-chart-stage {
+    height: 390px;
+    padding-left: 2px;
+    padding-right: 2px;
+  }
+
+  .tv-summary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 430px) {
+  .tv-brand p {
+    display: none;
+  }
+
+  .tv-brand-icon {
+    display: none;
+  }
+
+  .tv-switches {
+    grid-template-columns: 1fr;
+  }
+
+  .tv-chart-stage {
+    height: 330px;
+  }
 }
 
 /******************


### PR DESCRIPTION
## Summary

- redesign the TV Show Trends page with a responsive, chart-first interface
- combine title, IMDb ID, and IMDb URL searches into one automatically detected field
- resolve IMDb searches back to the canonical show title
- add persistent light and dark modes
- make the focused Y-axis an optional control while retaining the full 0–10 default
- use stable show colors and distinct full-series trendlines during comparisons
- add rating summaries and clearer loading and error states
- safely encode episode titles in API requests

## Verification

- JavaScript syntax checks pass for the chart controller and episode service
- ERB template syntax check passes
- targeted controller checks pass for IMDb detection/resolution, theme persistence, optional focused-axis scaling, summaries, and comparison trendlines
- git diff whitespace validation passes

Full Rails tests and asset compilation were not run locally because this machine has Ruby 2.6 while the repository requires Ruby 3.3+ and Bundler 4.